### PR TITLE
Feat/#20 custom date picker component

### DIFF
--- a/WithSuhyeon-iOS/WithSuhyeon-iOS/Core/DesignSystem/Component/CustomDatePicker.swift
+++ b/WithSuhyeon-iOS/WithSuhyeon-iOS/Core/DesignSystem/Component/CustomDatePicker.swift
@@ -25,9 +25,9 @@ struct CustomDatePicker: View {
     var body: some View {
         HStack(spacing: 16) {
             ZStack {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.primary50)
-                    .frame(width: 136, height: 46)
+                RoundedRectangle(cornerRadius: 8)
+                 .fill(Color.primary50)
+                 .frame(width: 124, height: 32)
                 
                 Picker("Date", selection: Binding(
                     get: { selectedDateIndex },
@@ -41,13 +41,13 @@ struct CustomDatePicker: View {
                     }
                 }
                 .pickerStyle(.wheel)
-                .frame(width: 140, height: 150)
+                .frame(width: 142, height: .infinity)
             }
             
             ZStack() {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.primary50)
-                    .frame(width: 60, height: 46)
+                RoundedRectangle(cornerRadius: 8)
+                 .fill(Color.primary50)
+                 .frame(width: 62, height: 32)
                 
                 Picker("AM/PM", selection: Binding(
                     get: { selectedAmPm },
@@ -65,9 +65,9 @@ struct CustomDatePicker: View {
             }
             
             ZStack {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.primary50)
-                    .frame(width: 109, height: 46)
+                RoundedRectangle(cornerRadius: 8)
+                 .fill(Color.primary50)
+                 .frame(width: 98, height: 32)
                 
                 HStack(spacing: 0) {
                     Picker("Hour", selection: Binding(
@@ -79,23 +79,32 @@ struct CustomDatePicker: View {
                                 .tag(hour)
                                 .foregroundColor(Color.gray800)
                                 .font(.title03SB)
+                                .padding(.vertical, 20)
                         }
                     }
                     .pickerStyle(.wheel)
-                    .frame(width: 70, height: 150)
+                    .clipShape(.rect.offset(x: -16))
+                    .padding(.trailing, -16)
+                    .frame(width: 60, height: .infinity)
                     
                     Picker("Minute", selection: Binding(
                         get: { selectedMinute },
                         set: { onMinuteChange($0) }
                     )) {
                         ForEach(minutes, id: \.self) { minute in
-                            Text(String(format: "%02d", minute))
-                                .tag(minute)
-                                .foregroundColor(Color.gray800)
-                                .font(.title03SB)
+                            ZStack {
+                                Text(String(format: "%02d", minute))
+                                    .tag(minute)
+                                    .foregroundColor(Color.gray800)
+                                    .font(.title03SB)
+                                    .padding(.vertical, 20)
+                            }
                         }
                     }
                     .pickerStyle(.wheel)
+                    .clipShape(.rect.offset(x: 16))
+                    .padding(.leading, -16)
+                    .frame(height: .infinity)
                 }
             }
         }
@@ -109,6 +118,7 @@ struct DatePickerView: View {
     @State private var selectedMinute: Int = 0
     @State private var selectedAmPm: String = "오전"
     
+    @State var selectedNumber: Int = 3
     private let dates: [String] = generateDatesForYear()
     private let hours = Array(1...12)
     private let minutes = stride(from: 0, to: 60, by: 5).map { $0 }
@@ -116,19 +126,19 @@ struct DatePickerView: View {
     
     var body: some View {
         CustomDatePicker(
-            selectedDateIndex: selectedDateIndex,
-            selectedHour: selectedHour,
-            selectedMinute: selectedMinute,
-            selectedAmPm: selectedAmPm,
-            dates: dates,
-            hours: hours,
-            minutes: minutes,
-            amPm: amPm,
-            onDateChange: { selectedDateIndex = $0 },
-            onHourChange: { selectedHour = $0 },
-            onMinuteChange: { selectedMinute = $0 },
-            onAmPmChange: { selectedAmPm = $0 }
-        )
+         selectedDateIndex: selectedDateIndex,
+         selectedHour: selectedHour,
+         selectedMinute: selectedMinute,
+         selectedAmPm: selectedAmPm,
+         dates: dates,
+         hours: hours,
+         minutes: minutes,
+         amPm: amPm,
+         onDateChange: { selectedDateIndex = $0 },
+         onHourChange: { selectedHour = $0 },
+         onMinuteChange: { selectedMinute = $0 },
+         onAmPmChange: { selectedAmPm = $0 }
+         )
     }
     
     static func generateDatesForYear() -> [String] {

--- a/WithSuhyeon-iOS/WithSuhyeon-iOS/Core/DesignSystem/Component/CustomDatePicker.swift
+++ b/WithSuhyeon-iOS/WithSuhyeon-iOS/Core/DesignSystem/Component/CustomDatePicker.swift
@@ -1,0 +1,151 @@
+//
+//  CustomDatePicker.swift
+//  WithSuhyeon-iOS
+//
+//  Created by  정지원 on 1/15/25.
+//
+import SwiftUI
+
+struct CustomDatePicker: View {
+    let selectedDateIndex: Int
+    let selectedHour: Int
+    let selectedMinute: Int
+    let selectedAmPm: String
+    
+    let dates: [String]
+    let hours: [Int]
+    let minutes: [Int]
+    let amPm: [String]
+    
+    let onDateChange: (Int) -> Void
+    let onHourChange: (Int) -> Void
+    let onMinuteChange: (Int) -> Void
+    let onAmPmChange: (String) -> Void
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.primary50)
+                    .frame(width: 136, height: 46)
+                
+                Picker("Date", selection: Binding(
+                    get: { selectedDateIndex },
+                    set: { onDateChange($0) }
+                )) {
+                    ForEach(0..<dates.count, id: \.self) { index in
+                        Text(dates[index])
+                            .tag(index)
+                            .foregroundColor(Color.gray800)
+                            .font(.title03SB)
+                    }
+                }
+                .pickerStyle(.wheel)
+                .frame(width: 140, height: 150)
+            }
+            
+            ZStack() {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.primary50)
+                    .frame(width: 60, height: 46)
+                
+                Picker("AM/PM", selection: Binding(
+                    get: { selectedAmPm },
+                    set: { onAmPmChange($0) }
+                )) {
+                    ForEach(amPm, id: \.self) { period in
+                        Text(period)
+                            .tag(period)
+                            .foregroundColor(Color.gray800)
+                            .font(.title03SB)
+                    }
+                }
+                .pickerStyle(.wheel)
+                .frame(width: 80, height: 150)
+            }
+            
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.primary50)
+                    .frame(width: 109, height: 46)
+                
+                HStack(spacing: 0) {
+                    Picker("Hour", selection: Binding(
+                        get: { selectedHour },
+                        set: { onHourChange($0) }
+                    )) {
+                        ForEach(hours, id: \.self) { hour in
+                            Text(String(format: "%02d", hour))
+                                .tag(hour)
+                                .foregroundColor(Color.gray800)
+                                .font(.title03SB)
+                        }
+                    }
+                    .pickerStyle(.wheel)
+                    .frame(width: 70, height: 150)
+                    
+                    Picker("Minute", selection: Binding(
+                        get: { selectedMinute },
+                        set: { onMinuteChange($0) }
+                    )) {
+                        ForEach(minutes, id: \.self) { minute in
+                            Text(String(format: "%02d", minute))
+                                .tag(minute)
+                                .foregroundColor(Color.gray800)
+                                .font(.title03SB)
+                        }
+                    }
+                    .pickerStyle(.wheel)
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+struct DatePickerView: View {
+    @State private var selectedDateIndex: Int = 0
+    @State private var selectedHour: Int = 9
+    @State private var selectedMinute: Int = 0
+    @State private var selectedAmPm: String = "오전"
+    
+    private let dates: [String] = generateDatesForYear()
+    private let hours = Array(1...12)
+    private let minutes = stride(from: 0, to: 60, by: 5).map { $0 }
+    private let amPm = ["오전", "오후"]
+    
+    var body: some View {
+        CustomDatePicker(
+            selectedDateIndex: selectedDateIndex,
+            selectedHour: selectedHour,
+            selectedMinute: selectedMinute,
+            selectedAmPm: selectedAmPm,
+            dates: dates,
+            hours: hours,
+            minutes: minutes,
+            amPm: amPm,
+            onDateChange: { selectedDateIndex = $0 },
+            onHourChange: { selectedHour = $0 },
+            onMinuteChange: { selectedMinute = $0 },
+            onAmPmChange: { selectedAmPm = $0 }
+        )
+    }
+    
+    static func generateDatesForYear() -> [String] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "M월 d일 E"
+        formatter.locale = Locale(identifier: "ko_KR")
+        let calendar = Calendar.current
+        
+        let startDate = calendar.date(from: DateComponents(year: 2025, month: 1, day: 1))!
+        let endDate = calendar.date(from: DateComponents(year: 2025, month: 12, day: 31))!
+        
+        return stride(from: startDate, to: endDate, by: 60 * 60 * 24).map {
+            formatter.string(from: $0)
+        }
+    }
+}
+
+#Preview {
+    DatePickerView()
+}

--- a/WithSuhyeon-iOS/WithSuhyeon-iOS/Core/DesignSystem/Foundation/Font+.swift
+++ b/WithSuhyeon-iOS/WithSuhyeon-iOS/Core/DesignSystem/Foundation/Font+.swift
@@ -32,18 +32,6 @@ public extension Font {
         return font(.suitRegular, ofSize: 28)
     }
     
-    static var heading03B: Font {
-        return font(.suitBold, ofSize: 26)
-    }
-    
-    static var heading03SB: Font {
-        return font(.suitSemiBold, ofSize: 26)
-    }
-    
-    static var heading03R: Font {
-        return font(.suitRegular, ofSize: 26)
-    }
-    
     static var title01B: Font {
         return font(.suitBold, ofSize: 24)
     }
@@ -57,14 +45,26 @@ public extension Font {
     }
     
     static var title02B: Font {
-        return font(.suitBold, ofSize: 20)
+        return font(.suitBold, ofSize: 22)
     }
     
     static var title02SB: Font {
-        return font(.suitSemiBold, ofSize: 20)
+        return font(.suitSemiBold, ofSize: 22)
     }
     
     static var title02R: Font {
+        return font(.suitRegular, ofSize: 22)
+    }
+    
+    static var title03B: Font {
+        return font(.suitBold, ofSize: 20)
+    }
+    
+    static var title03SB: Font {
+        return font(.suitSemiBold, ofSize: 20)
+    }
+    
+    static var title03R: Font {
         return font(.suitRegular, ofSize: 20)
     }
     


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
datePicker 컴포넌트를 커스텀했다.
![image](https://github.com/user-attachments/assets/1365f5bf-c078-4f6e-895e-a815127afade)


🌱 PR 포인트
### 문제 상황
1. 위의 사진과 같이 select tint color를 정해야 했는데, SwiftUI에서 Picker 색상을 커스텀하기 쉽지 않았다. tinted background 크기의 view를 추가하고 default tint color(gray)를 투명하게 설정하려 했는데, default color를 바꿀 수 있는 방법을 찾지 못했다.
2. 사진처럼 "시"와 "분"의 wheel은 따로 움직이되, 하나의 selected tint color background 안에 존재하게 구현하기가 어려웠다.
<img width="189" alt="image" src="https://github.com/user-attachments/assets/5bc9f56b-d81d-4424-b231-0e46962135e8" />


### 해결방법
리드의 아이디어로 해결했는데, "시"와 "분"의 wheel을 offset으로 겹치게 설정해서 이어지도록 보이게 했다. 
그리고 크기에 맞는 뷰를 만들어서 backgroundColor를 설정 후 wheel 위로 덮는 방식으로 해결했다. _~~야매~~_
```swift
Picker("Hour", selection: Binding(
                        get: { selectedHour },
                        set: { onHourChange($0) }
                    )) {
                        ForEach(hours, id: \.self) { hour in
                            Text(String(format: "%02d", hour))
                                .tag(hour)
                                .foregroundColor(Color.gray800)
                                .font(.title03SB)
                                .padding(.vertical, 20)
                        }
                    }
                    .pickerStyle(.wheel)
                    .clipShape(.rect.offset(x: -16))
                    .padding(.trailing, -16)
                    .frame(width: 60, height: .infinity)
```
### 결과
<img width="186" alt="image" src="https://github.com/user-attachments/assets/503286c8-d7e9-4ac8-bd57-d789cbdfd491" />


## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|
<!-- <img width="300" src="이미지 주소" /> -->
## 📮 관련 이슈
- Resolved: #20 
